### PR TITLE
improvements in the usage of constraint layout and solved issue

### DIFF
--- a/app/app/src/main/java/com/globant/calculator/android/mvp/presenter/CalculatorPresenter.java
+++ b/app/app/src/main/java/com/globant/calculator/android/mvp/presenter/CalculatorPresenter.java
@@ -64,7 +64,7 @@ public class CalculatorPresenter {
 
     public void onEqualsButtonPressed() {
         if ((!model.getFirstNumber().isEmpty()) && (!model.getSecondNumber().isEmpty()) &&
-            (!model.getFirstNumber().equals(DOT_BUTTON)) && (!model.getSecondNumber().equals(DOT_BUTTON)) ) {
+                (!model.getFirstNumber().equals(DOT_BUTTON)) && (!model.getSecondNumber().equals(DOT_BUTTON))) {
             view.showResult(calculateResult());
             model.clear();
         } else if (model.getOperator().isEmpty() && (!model.getFirstNumber().equals(DOT_BUTTON))) {

--- a/app/app/src/main/java/com/globant/calculator/android/mvp/presenter/CalculatorPresenter.java
+++ b/app/app/src/main/java/com/globant/calculator/android/mvp/presenter/CalculatorPresenter.java
@@ -63,10 +63,11 @@ public class CalculatorPresenter {
     }
 
     public void onEqualsButtonPressed() {
-        if ((!model.getFirstNumber().isEmpty()) && (!model.getSecondNumber().isEmpty())) {
+        if ((!model.getFirstNumber().isEmpty()) && (!model.getSecondNumber().isEmpty()) &&
+            (!model.getFirstNumber().equals(DOT_BUTTON)) && (!model.getSecondNumber().equals(DOT_BUTTON)) ) {
             view.showResult(calculateResult());
             model.clear();
-        } else if (model.getOperator().isEmpty()) {
+        } else if (model.getOperator().isEmpty() && (!model.getFirstNumber().equals(DOT_BUTTON))) {
             view.showResult(model.getFirstNumber());
             model.clear();
         } else {

--- a/app/app/src/main/res/layout/activity_main.xml
+++ b/app/app/src/main/res/layout/activity_main.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fillViewport="true"
-    android:scrollbarStyle="insideInset"
-    android:scrollbars="vertical"
-    app:layout_constraintBottom_toTopOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    android:scrollbars="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/activity_main"

--- a/app/app/src/main/res/layout/activity_main.xml
+++ b/app/app/src/main/res/layout/activity_main.xml
@@ -70,7 +70,6 @@
             android:id="@+id/number_one"
             style="@style/numberButtonStyle"
             android:layout_width="wrap_content"
-
             android:layout_height="wrap_content"
             android:text="@string/button_one"
             app:layout_constraintBottom_toTopOf="@id/number_four"

--- a/app/app/src/main/res/layout/activity_main.xml
+++ b/app/app/src/main/res/layout/activity_main.xml
@@ -26,7 +26,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-
         <TextView
             android:id="@+id/input_label"
             android:layout_width="wrap_content"

--- a/app/app/src/main/res/layout/activity_main.xml
+++ b/app/app/src/main/res/layout/activity_main.xml
@@ -1,177 +1,248 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/activity_main"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/main_background"
-    android:orientation="vertical">
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:fillViewport="true"
+    android:scrollbarStyle="insideInset"
+    android:scrollbars="vertical"
+    app:layout_constraintBottom_toTopOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
 
-    <TextView
-        android:id="@+id/calculation_label"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/activity_main"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/label_background"
-        android:hint="@string/label"
-        android:maxLines="@integer/max_lines_label"
-        android:textSize="@dimen/activity_calculation_label_text_size"
-        app:layout_constraintBottom_toTopOf="@+id/input_label"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:background="@color/main_background"
+        android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/input_label"
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/input_label_height"
-        android:background="@color/label_background"
-        android:hint="@string/label"
-        android:maxLines="@integer/max_lines_label"
-        android:textSize="@dimen/activity_input_label_text_size"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/calculation_label" />
+        <TextView
+            android:id="@+id/calculation_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/label_background"
+            android:hint="@string/label"
+            android:maxLines="@integer/max_lines_label"
+            android:textSize="@dimen/activity_calculation_label_text_size"
+            app:layout_constraintBottom_toTopOf="@+id/input_label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-        android:id="@+id/clear_button"
-        style="@style/clearButtonStyle"
-        android:text="@string/clear"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/input_label" />
 
-    <Button
-        android:id="@+id/delete_current_button"
-        style="@style/clearButtonStyle"
-        android:text="@string/delete_button"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/clear_button" />
+        <TextView
+            android:id="@+id/input_label"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/input_label_height"
+            android:background="@color/label_background"
+            android:hint="@string/label"
+            android:maxLines="@integer/max_lines_label"
+            android:textSize="@dimen/activity_input_label_text_size"
+            app:layout_constraintBottom_toTopOf="@id/clear_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/calculation_label" />
 
-    <Button
-        android:id="@+id/number_one"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_one"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toStartOf="@id/number_two"
-        app:layout_constraintTop_toBottomOf="@id/input_label" />
+        <Button
+            android:id="@+id/clear_button"
+            style="@style/clearButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/clear"
+            app:layout_constraintBottom_toTopOf="@id/delete_current_button"
+            app:layout_constraintEnd_toStartOf="@id/number_one"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/input_label" />
 
-    <Button
-        android:id="@+id/number_two"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_two"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toStartOf="@id/number_three"
-        app:layout_constraintTop_toBottomOf="@id/input_label" />
+        <Button
+            android:id="@+id/delete_current_button"
+            style="@style/clearButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/delete_button"
+            app:layout_constraintBottom_toTopOf="@id/add_button"
+            app:layout_constraintEnd_toStartOf="@id/number_four"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/clear_button" />
 
-    <Button
-        android:id="@+id/number_three"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_three"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/input_label" />
+        <Button
+            android:id="@+id/number_one"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
 
-    <Button
-        android:id="@+id/number_four"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_four"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toStartOf="@id/number_five"
-        app:layout_constraintTop_toBottomOf="@id/clear_button" />
+            android:layout_height="wrap_content"
+            android:text="@string/button_one"
+            app:layout_constraintBottom_toTopOf="@id/number_four"
+            app:layout_constraintEnd_toStartOf="@id/number_two"
+            app:layout_constraintStart_toEndOf="@id/clear_button"
+            app:layout_constraintTop_toBottomOf="@id/input_label" />
 
-    <Button
-        android:id="@+id/number_five"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_five"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toStartOf="@id/number_six"
-        app:layout_constraintTop_toBottomOf="@id/clear_button" />
+        <Button
+            android:id="@+id/number_two"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_two"
+            app:layout_constraintBottom_toTopOf="@id/number_five"
+            app:layout_constraintEnd_toStartOf="@id/number_three"
+            app:layout_constraintStart_toEndOf="@id/number_one"
+            app:layout_constraintTop_toBottomOf="@id/input_label" />
 
-    <Button
-        android:id="@+id/number_six"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_six"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/clear_button" />
+        <Button
+            android:id="@+id/number_three"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_three"
+            app:layout_constraintBottom_toTopOf="@id/number_six"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/number_two"
+            app:layout_constraintTop_toBottomOf="@id/input_label" />
 
-    <Button
-        android:id="@+id/number_seven"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_seven"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toStartOf="@id/number_eight"
-        app:layout_constraintTop_toBottomOf="@id/delete_current_button" />
+        <Button
+            android:id="@+id/number_four"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_four"
+            app:layout_constraintBottom_toTopOf="@id/number_seven"
+            app:layout_constraintEnd_toStartOf="@id/number_five"
+            app:layout_constraintStart_toEndOf="@id/delete_current_button"
+            app:layout_constraintTop_toBottomOf="@id/number_one" />
 
-    <Button
-        android:id="@+id/number_eight"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_eight"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toStartOf="@id/number_nine"
-        app:layout_constraintTop_toBottomOf="@id/delete_current_button" />
+        <Button
+            android:id="@+id/number_five"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_five"
+            app:layout_constraintBottom_toTopOf="@id/number_eight"
+            app:layout_constraintEnd_toStartOf="@id/number_six"
+            app:layout_constraintStart_toEndOf="@id/number_four"
+            app:layout_constraintTop_toBottomOf="@id/number_two" />
 
-    <Button
-        android:id="@+id/number_nine"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_nine"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/delete_current_button" />
+        <Button
+            android:id="@+id/number_six"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_six"
+            app:layout_constraintBottom_toTopOf="@id/number_nine"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/number_five"
+            app:layout_constraintTop_toBottomOf="@id/number_three" />
 
-    <Button
-        android:id="@+id/number_zero"
-        style="@style/numberButtonStyle"
-        android:text="@string/button_zero"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toEndOf="@id/number_eight"
-        app:layout_constraintTop_toBottomOf="@id/add_button" />
+        <Button
+            android:id="@+id/number_seven"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_seven"
+            app:layout_constraintBottom_toTopOf="@id/dot_button"
+            app:layout_constraintEnd_toStartOf="@id/number_eight"
+            app:layout_constraintStart_toEndOf="@id/add_button"
+            app:layout_constraintTop_toBottomOf="@id/number_four" />
 
-    <Button
-        android:id="@+id/add_button"
-        style="@style/actionButtonStyle"
-        android:text="@string/plus"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/delete_current_button" />
+        <Button
+            android:id="@+id/number_eight"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_eight"
+            app:layout_constraintBottom_toTopOf="@id/number_zero"
+            app:layout_constraintEnd_toStartOf="@id/number_nine"
+            app:layout_constraintStart_toEndOf="@id/number_seven"
+            app:layout_constraintTop_toBottomOf="@id/number_five" />
 
-    <Button
-        android:id="@+id/subtraction_button"
-        style="@style/actionButtonStyle"
-        android:text="@string/minus"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/add_button" />
+        <Button
+            android:id="@+id/number_nine"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_nine"
+            app:layout_constraintBottom_toTopOf="@id/equals_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/number_eight"
+            app:layout_constraintTop_toBottomOf="@id/number_six" />
 
-    <Button
-        android:id="@+id/multiply_button"
-        style="@style/actionButtonStyle"
-        android:text="@string/multiply"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtraction_button" />
+        <Button
+            android:id="@+id/number_zero"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_zero"
+            app:layout_constraintBottom_toBottomOf="@id/dot_button"
+            app:layout_constraintEnd_toStartOf="@id/equals_button"
+            app:layout_constraintStart_toEndOf="@id/dot_button"
+            app:layout_constraintTop_toTopOf="@id/dot_button" />
 
-    <Button
-        android:id="@+id/divide_button"
-        style="@style/actionButtonStyle"
-        android:text="@string/divide"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/multiply_button" />
+        <Button
+            android:id="@+id/add_button"
+            style="@style/actionButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/plus"
+            app:layout_constraintBottom_toTopOf="@id/subtraction_button"
+            app:layout_constraintEnd_toStartOf="@id/number_seven"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/delete_current_button" />
 
-    <Button
-        android:id="@+id/equals_button"
-        style="@style/numberButtonStyle"
-        android:text="@string/equals"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/add_button" />
+        <Button
+            android:id="@+id/subtraction_button"
+            style="@style/actionButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/minus"
+            app:layout_constraintBottom_toTopOf="@id/multiply_button"
+            app:layout_constraintEnd_toStartOf="@id/dot_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/add_button" />
 
-    <Button
-        android:id="@+id/dot_button"
-        style="@style/numberButtonStyle"
-        android:text="@string/dot_button"
-        android:textColor="@color/button_text_color"
-        app:layout_constraintEnd_toEndOf="@id/number_seven"
-        app:layout_constraintTop_toBottomOf="@id/add_button" />
+        <Button
+            android:id="@+id/multiply_button"
+            style="@style/actionButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/multiply"
+            app:layout_constraintBottom_toTopOf="@id/divide_button"
+            app:layout_constraintEnd_toEndOf="@id/subtraction_button"
+            app:layout_constraintStart_toStartOf="@id/subtraction_button"
+            app:layout_constraintTop_toBottomOf="@id/subtraction_button" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <Button
+            android:id="@+id/divide_button"
+            style="@style/actionButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/divide"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/subtraction_button"
+            app:layout_constraintStart_toStartOf="@id/subtraction_button"
+            app:layout_constraintTop_toBottomOf="@id/multiply_button" />
+
+        <Button
+            android:id="@+id/equals_button"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/equals"
+            app:layout_constraintBottom_toBottomOf="@id/number_zero"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/number_zero"
+            app:layout_constraintTop_toTopOf="@id/number_zero" />
+
+        <Button
+            android:id="@+id/dot_button"
+            style="@style/numberButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dot_button"
+            app:layout_constraintBottom_toBottomOf="@id/subtraction_button"
+            app:layout_constraintEnd_toStartOf="@id/number_zero"
+            app:layout_constraintStart_toEndOf="@id/subtraction_button"
+            app:layout_constraintTop_toTopOf="@id/subtraction_button" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Calculator Onboarding</string>
     <string name="button_zero">0</string>
-    <string name="clear">clear</string>
+    <string name="clear">Clear</string>
     <string name="button_one">1</string>
     <string name="button_two">2</string>
     <string name="button_three">3</string>
@@ -19,5 +19,6 @@
     <string name="label">0</string>
     <string name="dot_button">.</string>
     <string name="invalid_operation">Invalid operation</string>
-    <string name="delete_button">DEL</string>
+    <string name="delete_button">Del</string>
+    <string name="false_option">false</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -18,6 +18,6 @@
     <string name="equals">=</string>
     <string name="label">0</string>
     <string name="dot_button">.</string>
-    <string name="invalid_operation">Invalid Operation</string>
+    <string name="invalid_operation">Invalid operation</string>
     <string name="delete_button">DEL</string>
 </resources>

--- a/app/app/src/main/res/values/styles.xml
+++ b/app/app/src/main/res/values/styles.xml
@@ -7,21 +7,23 @@
     </style>
 
     <style name="actionButtonStyle">
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_width">@dimen/activity_button_width</item>
+        <item name="android:layout_margin">0dp</item>
+        <item name="android:textColor">@color/button_text_color</item>
         <item name="android:backgroundTint">@color/action_button_color</item>
         <item name="android:textSize">@dimen/action_button_text_size</item>
     </style>
 
     <style name="clearButtonStyle">
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_width">@dimen/activity_button_width</item>
+        <item name="android:layout_margin">0dp</item>
+
+        <item name="android:textColor">@color/button_text_color</item>
         <item name="android:backgroundTint">@color/clear_button</item>
     </style>
 
     <style name="numberButtonStyle">
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_margin">0dp</item>
+
+        <item name="android:textColor">@color/button_text_color</item>
         <item name="android:backgroundTint">@color/number_button_color</item>
         <item name="android:textSize">@dimen/number_button_text_size</item>
     </style>

--- a/app/app/src/main/res/values/styles.xml
+++ b/app/app/src/main/res/values/styles.xml
@@ -7,22 +7,18 @@
     </style>
 
     <style name="actionButtonStyle">
-        <item name="android:layout_margin">0dp</item>
         <item name="android:textColor">@color/button_text_color</item>
         <item name="android:backgroundTint">@color/action_button_color</item>
         <item name="android:textSize">@dimen/action_button_text_size</item>
     </style>
 
     <style name="clearButtonStyle">
-        <item name="android:layout_margin">0dp</item>
-
+        <item name="android:textAllCaps">false</item>
         <item name="android:textColor">@color/button_text_color</item>
         <item name="android:backgroundTint">@color/clear_button</item>
     </style>
 
     <style name="numberButtonStyle">
-        <item name="android:layout_margin">0dp</item>
-
         <item name="android:textColor">@color/button_text_color</item>
         <item name="android:backgroundTint">@color/number_button_color</item>
         <item name="android:textSize">@dimen/number_button_text_size</item>


### PR DESCRIPTION
Some improvements in the constraints of the objects on the activity layout.

Added a scrollbar so the application can be fully seen on smaller devices. 

Solved an issue when doing operations with just a .(dot) as a value, now is not allowed. In the GIF i show what happen pressing equals with a .(dot) as an operator on the first and the second number.

Change buttons to not be all-caps from the get go.

![constraint and dot](https://user-images.githubusercontent.com/61156888/75907854-d6480100-5e27-11ea-969c-4c8084e3a458.gif)





